### PR TITLE
main.rs: Fix positional argument matching names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
         )
         .get_matches();
 
-    match (matches.value_of("INPUT_A"), matches.value_of("INPUT_B")) {
+    match (matches.value_of("INPUT-A"), matches.value_of("INPUT-B")) {
         (Some(file_a), Some(file_b)) => {
             let pass_a = match matches.value_of("password-a") {
                 Some(password) => password.to_string(),


### PR DESCRIPTION
Fix the names of the positional arguments `INPUT-A` and `INPUT-B` in the `match` call to "match" the names given to the arguments above.