### PR TITLE
Readme add example with passwords provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ The CLI will ask for the password for both files individually.
 
 ![Example Screencast](docs/screencast.gif)
 
+You can also provide one or both passwords on the command line (please be aware
+that this will expose them to other users logged on to the system):
+
+```
+cargo run -- <file-a> <file-b> --password-a <password-a> --password-b <password-b>
+
+(the -- is necessary for cargo to pass the arguments through to keepass-diff)
+
 ## Used libraries:
 
 * [rpassword](https://github.com/conradkdotcom/rpassword) to read the passwords.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ that this will expose them to other users logged on to the system):
 
 ```
 cargo run -- <file-a> <file-b> --password-a <password-a> --password-b <password-b>
+```
 
 (the -- is necessary for cargo to pass the arguments through to keepass-diff)
 


### PR DESCRIPTION
Added a simple example for providing passwords on the command line to the README