### PR TITLE
Set fixed version to circumvent incompatibility with newer version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ exclude = [
 
 [dependencies]
 clap = "2.33.0"
-keepass = "0.4.5"
+keepass = "=0.4.5"
 rpassword = "4.0.3"
 termcolor = "1.0.5"


### PR DESCRIPTION
The code should be updated to use the newer version, but this works as a quick fix.

By default, Cargo.toml will pick the latest patch version, which is incompatible. The equals sign forces cargo to use that exact version.