### PR TITLE
Provide option to use keepass-diff in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,7 @@
 FROM rust:latest
+
+RUN RUSTFLAGS="-C target-cpu=native" cargo install keepass-diff
+
 WORKDIR /app
+
+ENTRYPOINT ["keepass-diff"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ RUSTFLAGS="-C target-cpu=native" cargo install keepass-diff
 The `RUSTFLAGS` variable will significantly boost performance. See
 [installation note in keepass-rs](https://github.com/sseemayer/keepass-rs#installation).
 
+### Using a container
+
+*NOTE: You can also replace `podman` with `docker` below.*
+
+Build container image:
+```
+podman build --iidfile=container_image_id .
+```
+
+Define alias to run keepass-diff container:
+```
+alias keepass-diff="podman run -it --rm -v "'`pwd`'":/app:z $(cat container_image_id)"
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
Optionally you could sync/push to a container registry.

Motivation: I personally prefer using containers for applications where I do not want to install the libraries for.
This gives a quick way to use keepass-diff in a container.