### PR TITLE
Fix docker build

### DIFF
--- a/Containerfile.install
+++ b/Containerfile.install
@@ -1,7 +1,7 @@
 ##
 # BUILD STAGE
 #############
-FROM ekidd/rust-musl-builder:latest AS builder
+FROM clux/muslrust:stable AS builder
 
 ENV RUSTFLAGS="-C target-cpu=native"
 
@@ -25,5 +25,5 @@ RUN cargo build --release
 #############
 FROM scratch
 WORKDIR /app
-COPY --from=builder /home/rust/src/target/x86_64-unknown-linux-musl/release/keepass-diff /usr/local/bin/
+COPY --from=builder /volume/target/x86_64-unknown-linux-musl/release/keepass-diff /usr/local/bin/
 ENTRYPOINT [ "/usr/local/bin/keepass-diff" ]


### PR DESCRIPTION
The current version did not work with latest M1/M2 chips or newer Mac OS X versions. I've changed the underlying docker image for building. I think this has increased the build size a bit, but at least it works again (the new docker image has 6.51mb)

Fixes #50 