### PR TITLE
style: clippy changes

### DIFF
--- a/src/diff/group.rs
+++ b/src/diff/group.rs
@@ -23,23 +23,21 @@ impl Group {
 
         let mut child_groups: HashMap<String, Vec<Group>> = HashMap::new();
         for node in group.children.iter() {
-            match node {
-                keepass::db::Node::Group(g) => child_groups
+            if let keepass::db::Node::Group(g) = node {
+                child_groups
                     .entry(g.name.clone())
-                    .or_insert(Vec::new())
-                    .push(Group::from_keepass(g, use_verbose, mask_passwords)),
-                _ => {}
+                    .or_default()
+                    .push(Group::from_keepass(g, use_verbose, mask_passwords))
             }
         }
 
         let mut entries: HashMap<String, Vec<Entry>> = HashMap::new();
         for node in group.children.iter() {
-            match node {
-                keepass::db::Node::Entry(e) => entries
+            if let keepass::db::Node::Entry(e) = node {
+                entries
                     .entry(e.get("Title").unwrap_or_default().to_owned())
-                    .or_insert(Vec::new())
-                    .push(Entry::from_keepass(e, use_verbose, mask_passwords)),
-                _ => {}
+                    .or_default()
+                    .push(Entry::from_keepass(e, use_verbose, mask_passwords))
             }
         }
 

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -56,9 +56,9 @@ pub struct DiffDisplay<'a, T: DiffResultFormat> {
 }
 
 impl<'a, T: DiffResultFormat> std::fmt::Display for DiffDisplay<'a, T> {
-    fn fmt(&self, mut f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let result = self.inner.diff_result_format(
-            &mut f,
+            f,
             &self.path,
             self.use_color,
             self.use_verbose,
@@ -78,7 +78,7 @@ where
 {
     fn diff_result_format(
         &self,
-        mut f: &mut std::fmt::Formatter<'_>,
+        f: &mut std::fmt::Formatter<'_>,
         path: &Stack<&String>,
         use_color: bool,
         use_verbose: bool,
@@ -92,11 +92,11 @@ where
                 }
                 if use_verbose {
                     let indent = "  ".repeat(path.len());
-                    write!(f, "- {}{}\n", indent, left)?;
+                    writeln!(f, "- {}{}", indent, left)?;
                 } else {
-                    write!(
+                    writeln!(
                         f,
-                        "- {}\n",
+                        "- {}",
                         path.append(&format!("{}", left)).mk_string("[", ", ", "]")
                     )?;
                 }
@@ -105,11 +105,11 @@ where
                 }
                 if use_verbose {
                     let indent = "  ".repeat(path.len());
-                    write!(f, "+ {}{}\n", indent, right)
+                    writeln!(f, "+ {}{}", indent, right)
                 } else {
-                    write!(
+                    writeln!(
                         f,
-                        "+ {}\n",
+                        "+ {}",
                         path.append(&format!("{}", right)).mk_string("[", ", ", "]")
                     )
                 }
@@ -124,11 +124,11 @@ where
                         crate::set_fg(Some(Color::Yellow));
                     }
                     let indent = "  ".repeat(path.len());
-                    write!(f, "~ {}{}\n", indent, left)?;
+                    writeln!(f, "~ {}{}", indent, left)?;
                 }
                 for id in inner_differences {
                     id.diff_result_format(
-                        &mut f,
+                        f,
                         &path.append(&format!("{}", left)),
                         use_color,
                         use_verbose,
@@ -143,11 +143,11 @@ where
                 }
                 if use_verbose {
                     let indent = "  ".repeat(path.len());
-                    write!(f, "- {}{}\n", indent, left)
+                    writeln!(f, "- {}{}", indent, left)
                 } else {
-                    write!(
+                    writeln!(
                         f,
-                        "- {}\n",
+                        "- {}",
                         path.append(&format!("{}", left)).mk_string("[", ", ", "]")
                     )
                 }
@@ -158,11 +158,11 @@ where
                 }
                 if use_verbose {
                     let indent = "  ".repeat(path.len());
-                    write!(f, "+ {}{}\n", indent, right)
+                    writeln!(f, "+ {}{}", indent, right)
                 } else {
-                    write!(
+                    writeln!(
                         f,
-                        "+ {}\n",
+                        "+ {}",
                         path.append(&format!("{}", right)).mk_string("[", ", ", "]")
                     )
                 }
@@ -255,7 +255,7 @@ where
         match (el_a, el_b) {
             // both a and b have the key
             (Some(v_a), Some(v_b)) => {
-                v_a.into_iter()
+                v_a.iter()
                     .enumerate()
                     .for_each(|(index, value_a)| match v_b.get(index) {
                         Some(value_b) => {
@@ -274,7 +274,7 @@ where
                 if v_a.len() < v_b.len() {
                     has_differences = true;
                     v_b[v_a.len()..]
-                        .into_iter()
+                        .iter()
                         .for_each(|value_b| acc.push(DiffResult::OnlyRight { right: value_b }));
                 }
             }
@@ -282,13 +282,13 @@ where
             // only a has the key
             (Some(v_a), None) => {
                 has_differences = true;
-                v_a.into_iter()
+                v_a.iter()
                     .for_each(|e| acc.push(DiffResult::OnlyLeft { left: e }));
             }
             // only b has the key
             (None, Some(v_b)) => {
                 has_differences = true;
-                v_b.into_iter()
+                v_b.iter()
                     .for_each(|e| acc.push(DiffResult::OnlyRight { right: e }));
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,60 +82,59 @@ struct Args {
 fn main() -> Result<(), ()> {
     let arguments = Args::parse();
 
-    match (arguments.input_a, arguments.input_b) {
-        (file_a, file_b) => {
-            let pass_a = match (
-                arguments.password_a,
-                arguments.passwords.clone(),
-                arguments.same_password,
-                arguments.no_password_a,
-                arguments.no_passwords,
-            ) {
-                (Some(password), _, _, _, _) => Some(String::from(password)),
-                (_, Some(password), _, _, _) => Some(String::from(password)),
-                (_, _, true, _, _) => prompt_password("Password for both files: "),
-                (_, _, _, true, _) => None,
-                (_, _, _, _, true) => None,
-                _ => prompt_password(format!("Password for file {}: ", file_a).as_str()),
-            };
-            let pass_b = match (
-                arguments.password_b,
-                arguments.passwords.clone(),
-                arguments.same_password,
-                arguments.no_password_b,
-                arguments.no_passwords,
-            ) {
-                (Some(password), _, _, _, _) => Some(String::from(password)),
-                (_, Some(password), _, _, _) => Some(String::from(password)),
-                (_, _, true, _, _) => pass_a.clone(),
-                (_, _, _, true, _) => None,
-                (_, _, _, _, true) => None,
-                _ => prompt_password(format!("Password for file {}: ", file_b).as_str()),
-            };
-            let keyfile_a: Option<String> = arguments.keyfile_a.or(arguments.keyfiles.clone());
-            let keyfile_b: Option<String> = arguments.keyfile_b.or(arguments.keyfiles.clone());
-            let use_color: bool = !arguments.no_color;
-            let use_verbose: bool = arguments.verbose;
-            let mask_passwords: bool = arguments.mask_passwords;
+    let (file_a, file_b) = (&arguments.input_a, &arguments.input_b);
+    {
+        let pass_a = match (
+            arguments.password_a,
+            arguments.passwords.clone(),
+            arguments.same_password,
+            arguments.no_password_a,
+            arguments.no_passwords,
+        ) {
+            (Some(password), _, _, _, _) => Some(password),
+            (_, Some(password), _, _, _) => Some(password),
+            (_, _, true, _, _) => prompt_password("Password for both files: "),
+            (_, _, _, true, _) => None,
+            (_, _, _, _, true) => None,
+            _ => prompt_password(format!("Password for file {}: ", file_a).as_str()),
+        };
+        let pass_b = match (
+            arguments.password_b,
+            arguments.passwords.clone(),
+            arguments.same_password,
+            arguments.no_password_b,
+            arguments.no_passwords,
+        ) {
+            (Some(password), _, _, _, _) => Some(password),
+            (_, Some(password), _, _, _) => Some(password),
+            (_, _, true, _, _) => pass_a.clone(),
+            (_, _, _, true, _) => None,
+            (_, _, _, _, true) => None,
+            _ => prompt_password(format!("Password for file {}: ", file_b).as_str()),
+        };
+        let keyfile_a: Option<String> = arguments.keyfile_a.or(arguments.keyfiles.clone());
+        let keyfile_b: Option<String> = arguments.keyfile_b.or(arguments.keyfiles.clone());
+        let use_color: bool = !arguments.no_color;
+        let use_verbose: bool = arguments.verbose;
+        let mask_passwords: bool = arguments.mask_passwords;
 
-            let db_a = kdbx_to_group(file_a, pass_a, keyfile_a, use_verbose, mask_passwords)
-                .expect("Error opening database A");
-            let db_b = kdbx_to_group(file_b, pass_b, keyfile_b, use_verbose, mask_passwords)
-                .expect("Error opening database B");
+        let db_a = kdbx_to_group(file_a, pass_a, keyfile_a, use_verbose, mask_passwords)
+            .expect("Error opening database A");
+        let db_b = kdbx_to_group(file_b, pass_b, keyfile_b, use_verbose, mask_passwords)
+            .expect("Error opening database B");
 
-            let delta = db_a.diff(&db_b);
+        let delta = db_a.diff(&db_b);
 
-            println!(
-                "{}",
-                DiffDisplay {
-                    inner: delta,
-                    path: stack::Stack::empty(),
-                    use_color,
-                    use_verbose,
-                    mask_passwords,
-                }
-            );
-        }
+        println!(
+            "{}",
+            DiffDisplay {
+                inner: delta,
+                path: stack::Stack::empty(),
+                use_color,
+                use_verbose,
+                mask_passwords,
+            }
+        );
     }
 
     Ok(())
@@ -143,12 +142,12 @@ fn main() -> Result<(), ()> {
 
 fn prompt_password(prompt: &str) -> Option<String> {
     rpassword::prompt_password(prompt)
-        .map(|s| if s == "" { None } else { Some(s) })
+        .map(|s| if s.is_empty() { None } else { Some(s) })
         .unwrap_or(None)
 }
 
 pub fn kdbx_to_group(
-    file: String,
+    file: &str,
     password: Option<String>,
     keyfile_path: Option<String>,
     use_verbose: bool,

--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::rc::Rc;
 
 pub struct Stack<T> {
@@ -43,11 +44,15 @@ impl<T> Stack<T> {
     }
 }
 
-impl<T: std::fmt::Display> Stack<T> {
-    pub fn to_string(&self) -> String {
-        self.mk_string("Stack(", ", ", ")")
+impl<T: Display> Display for Stack<T> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.mk_string("Stack(", ", ", ")"))
     }
+}
 
+impl<T: Display> Stack<T> {
+    #[inline]
     pub fn mk_string(
         &self,
         start: &'static str,
@@ -64,6 +69,7 @@ impl<T: std::fmt::Display> Stack<T> {
         }
     }
 
+    #[inline]
     fn mk_string_helper(&self, separator: &'static str) -> String {
         match self.head() {
             Some(value) => format!(
@@ -72,7 +78,7 @@ impl<T: std::fmt::Display> Stack<T> {
                 value,
                 separator,
             ),
-            None => format!(""),
+            None => String::new(),
         }
     }
 }


### PR DESCRIPTION
Changes:
- use `String:new()` instead of `format!("")`
- use `is_empty()` instead of `s == ""`
- use reference iterator instead of `into_iter`
- replace `write!` + '\n' with `writeln!`
- remove `mut` from vars with type `&mut ...`
- replace single branch `match` with `if` pattern match
- replace `Stack::to_string` with `Display` trait
- replace match with pattern matching in `fn main`
- use reference to file name, instead of direct ownership